### PR TITLE
Expose remove custom integration method(s)

### DIFF
--- a/runzero/api/admin/custom_integrations.py
+++ b/runzero/api/admin/custom_integrations.py
@@ -29,7 +29,8 @@ class CustomIntegrationAssetSet(BaseModel):
     A Pydantic-compliant class for marshaling custom asset ids.
     """
 
-    asset_ids: list[uuid.UUID] = Field(...)
+    asset_ids: List[uuid.UUID] = Field(...)
+
 
 class CustomIntegrationAttributeSet(BaseModel):
     """
@@ -260,7 +261,7 @@ class CustomIntegrationAssetAdmin:
 
         return res.json_obj.get("updated", 0)
 
-    def remove_custom_integration(self, org_id: uuid.UUID, asset_id: uuid.UUID):
+    def remove_custom_integration(self, org_id: uuid.UUID, asset_id: uuid.UUID) -> None:
         """
         Removes a custom integration from a specific asset.
 
@@ -276,7 +277,7 @@ class CustomIntegrationAssetAdmin:
             params={"_oid": org_id},
         )
 
-    def bulk_remove_custom_integration(self, org_id: uuid.UUID, asset_ids: list[uuid.UUID]):
+    def bulk_remove_custom_integration(self, org_id: uuid.UUID, asset_ids: List[uuid.UUID]) -> None:
         """
         Removes a custom integration from a list of assets.
 
@@ -290,7 +291,7 @@ class CustomIntegrationAssetAdmin:
             "POST",
             f"api/v1.0/org/custom-integrations/{self._id}/bulk/remove",
             params={"_oid": org_id},
-            data=CustomIntegrationAssetSet(asset_ids=asset_ids)
+            data=CustomIntegrationAssetSet(asset_ids=asset_ids),
         )
 
 

--- a/runzero/api/admin/custom_integrations.py
+++ b/runzero/api/admin/custom_integrations.py
@@ -253,6 +253,24 @@ class CustomIntegrationAssetAdmin:
 
         return res.json_obj.get("updated", 0)
 
+    def remove_custom_integration(self, org_id: uuid.UUID, asset_id: uuid.UUID) -> None:
+        """
+        Removes custom integration from a specific asset.
+
+        :param org_id: organization id
+        :param asset_id: the asset to update
+
+        :raises: AuthError, ClientError, ServerError
+        """
+
+        res = self._client.execute(
+            "DELETE",
+            f"api/v1.0/org/assets/{asset_id}/custom-integrations/{self._id}/remove",
+            params={"_oid": org_id},
+        )
+
+        return None
+
 
 class CustomIntegrationsAdmin:
     """Full Management of custom integrations.

--- a/runzero/api/admin/custom_integrations.py
+++ b/runzero/api/admin/custom_integrations.py
@@ -24,6 +24,13 @@ from runzero.types import (
 from ._sdk_source_icon import _PY_ICON_BYTES
 
 
+class CustomIntegrationAssetSet(BaseModel):
+    """
+    A Pydantic-compliant class for marshaling custom asset ids.
+    """
+
+    asset_ids: list[uuid.UUID] = Field(...)
+
 class CustomIntegrationAttributeSet(BaseModel):
     """
     A Pydantic-compliant class for marshaling custom attributes.
@@ -253,9 +260,9 @@ class CustomIntegrationAssetAdmin:
 
         return res.json_obj.get("updated", 0)
 
-    def remove_custom_integration(self, org_id: uuid.UUID, asset_id: uuid.UUID) -> None:
+    def remove_custom_integration(self, org_id: uuid.UUID, asset_id: uuid.UUID):
         """
-        Removes custom integration from a specific asset.
+        Removes a custom integration from a specific asset.
 
         :param org_id: organization id
         :param asset_id: the asset to update
@@ -263,13 +270,28 @@ class CustomIntegrationAssetAdmin:
         :raises: AuthError, ClientError, ServerError
         """
 
-        res = self._client.execute(
+        self._client.execute(
             "DELETE",
             f"api/v1.0/org/assets/{asset_id}/custom-integrations/{self._id}/remove",
             params={"_oid": org_id},
         )
 
-        return None
+    def bulk_remove_custom_integration(self, org_id: uuid.UUID, asset_ids: list[uuid.UUID]):
+        """
+        Removes a custom integration from a list of assets.
+
+        :param org_id: organization id
+        :param asset_ids: the list of assets to update
+
+        :raises: AuthError, ClientError, ServerError
+        """
+
+        self._client.execute(
+            "POST",
+            f"api/v1.0/org/custom-integrations/{self._id}/bulk/remove",
+            params={"_oid": org_id},
+            data=CustomIntegrationAssetSet(asset_ids=asset_ids)
+        )
 
 
 class CustomIntegrationsAdmin:


### PR DESCRIPTION
Expose API endpoints that remove custom integration sources from assets through the SDK:

```python
# Remove a custom integration source from single asset 
remove_custom_integration(self, org_id: uuid.UUID, asset_id: uuid.UUID)

# Remove a custom integration source from multiple assets
bulk_remove_custom_integration(self, org_id: uuid.UUID, asset_ids: List[uuid.UUID])
```