### PR TITLE
Bump versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1311,13 +1311,13 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.32.0"
+version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "requests-2.32.0-py3-none-any.whl", hash = "sha256:f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5"},
-    {file = "requests-2.32.0.tar.gz", hash = "sha256:fa5490319474c82ef1d2c9bc459d3652e3ae4ef4c4ebdd18a21145a47ca4b6b8"},
+    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
+    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
 ]
 
 [package.dependencies]
@@ -1686,4 +1686,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "9daaf5d6c3f8d43324223df3ead3cbd16d4c3d77e1fc744a29c2a648f642f2d8"
+content-hash = "df1b029ed8b60a169f7e88c266c88230a3f2e80b252107e78fc200d2896af8db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "runzero-sdk"
-version = "0.8.5"
+version = "0.8.6"
 description = "The runZero platform sdk"
 license = "BSD-2-Clause"
 authors = ["runZero <support@runzero.com>"]
@@ -34,7 +34,7 @@ optional = true
 [tool.poetry.dependencies]
 python = "^3.8"
 pydantic = ">=1.10.5,<2.0.0"
-requests = "^2.31.0"
+requests = "^2.32.3"
 # no standard mechanism to pin transitive deps
 # https://github.com/python-poetry/poetry/issues/4991
 certifi = ">=2024.2.2"


### PR DESCRIPTION
* Bump SDK revison
* Bump `requests` version due to being [yanked](https://pypi.org/project/requests/2.32.1/) from PyPi due to conflicts with CVE-2024-35195 mitigation

