### PR TITLE
Allow trusting custom integration fingerprints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "runzero-sdk"
-version = "0.8.6"
+version = "0.8.7"
 description = "The runZero platform sdk"
 license = "BSD-2-Clause"
 authors = ["runZero <support@runzero.com>"]

--- a/runzero/types/_data_models_gen.py
+++ b/runzero/types/_data_models_gen.py
@@ -1097,3 +1097,15 @@ class ImportAsset(BaseModel):
     """
     Flat map of arbitrary string key/value pairs representing custom attribute data not described in properties above. Note the maximum number of keys and length of values. Additionally, property names may only be 256 characters long.
     """
+    trust_os: Optional[bool] = Field(False, alias="trustOS", example=False)
+    """
+    If true, the provided OS value will be used even if it cannot be normalized using runZero's fingerprint engine.
+    """
+    trust_os_version: Optional[bool] = Field(False, alias="trustOSVersion", example=False)
+    """
+    If true, the provided OS version value will be used even if it cannot be normalized using runZero's fingerprint engine.
+    """
+    trust_device_type: Optional[bool] = Field(False, alias="trustDeviceType", example=False)
+    """
+    If true, the provided device type value will be used even if it cannot be normalized using runZero's fingerprint engine.
+    """


### PR DESCRIPTION
This adds three new `ImportAsset` attributes to allow custom integrations to specify that their fingerprint data should be trusted, even if the data cannot be normalized by runZero's fingerprint engine:

* `trust_os` - Trusts the `os` attribute and use it to set Asset OS
* `trust_os_version` - Trusts the `os_version` attribute and use it to set Asset OS
* `trust_device_type` - Trusts the `device_type` attribute and use to to set Asset Type

Without these options set, `os`, `os_version` and `device_type` will only be used to set the runZero asset fingerprint if they can be normalized via runZero's fingerprint engine.  `os`, `os_version` and `device_type` are always available under the custom integrations attributes, even when the corresponding `trust_*` options are not set.

## Example:

```py
asset = ImportAsset(
  id=f"test-asset-{i}",
  hostnames=[f"test-asset-{i}"],
  device_type="Custom Type",
  os="Custom OS",
  os_version="0.1.2",
  trust_device_type=True,
  trust_os=True,
  trust_os_version=True,
)
```